### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/public/sw-fetch-handlers.js
+++ b/public/sw-fetch-handlers.js
@@ -153,7 +153,7 @@ function isFontRequest(request) {
   // Check for common font paths
   if (url.pathname.startsWith('/fonts/') || 
       url.pathname.includes('/assets/fonts/') || 
-      url.hostname.includes('fonts.googleapis.com')) {
+      url.hostname === 'fonts.googleapis.com') {
     return true;
   }
   


### PR DESCRIPTION
Potential fix for [https://github.com/ken-guru/github-copilot-agent-assisted-next-app/security/code-scanning/7](https://github.com/ken-guru/github-copilot-agent-assisted-next-app/security/code-scanning/7)

To fix the issue, the code should explicitly check that the hostname of the URL matches `fonts.googleapis.com` exactly, rather than using a substring check. This can be achieved by comparing `url.hostname` directly to the expected value. This approach ensures that only requests to the exact domain `fonts.googleapis.com` are matched, preventing bypasses through maliciously crafted URLs.

The fix involves replacing the `url.hostname.includes('fonts.googleapis.com')` check with `url.hostname === 'fonts.googleapis.com'`. This change ensures that the hostname is validated correctly without introducing false positives.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
