### PR TITLE
Potential fix for code scanning alert no. 8: Missing origin verification in `postMessage` handler

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -236,7 +236,14 @@ self.addEventListener('fetch', (event) => {
 });
 
 // For debugging purposes
+const TRUSTED_ORIGIN = 'https://www.example.com';
+
 self.addEventListener('message', (event) => {
+  if (event.origin !== TRUSTED_ORIGIN) {
+    console.warn('[ServiceWorker] Ignored message from untrusted origin:', event.origin);
+    return;
+  }
+
   if (event.data === 'skipWaiting') {
     self.skipWaiting();
   }


### PR DESCRIPTION
Potential fix for [https://github.com/ken-guru/github-copilot-agent-assisted-next-app/security/code-scanning/8](https://github.com/ken-guru/github-copilot-agent-assisted-next-app/security/code-scanning/8)

To fix the issue, we will add an origin check to the `message` event handler. The handler will verify that the `event.origin` matches a trusted origin (e.g., `'https://www.example.com'`) before processing the message. If the origin does not match, the handler will ignore the message. This ensures that only messages from trusted sources are acted upon.

Steps to implement the fix:
1. Add a conditional check for `event.origin` in the `message` event handler.
2. Define the trusted origin(s) as a constant for maintainability.
3. Ignore messages from untrusted origins.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
