### PR TITLE
Refining the configuration for reviewers and labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,6 @@ updates:
     target-branch: "main" # Specify target branch explicitly
     reviewers:
       - "ken-guru"
-      - "team:frontend-devs" # Optional team reviewer
     assignees:
       - "ken-guru" # Add assignees for better tracking
     # Enabled security updates  
@@ -122,7 +121,6 @@ updates:
 
     labels:
       - "dependencies"
-      - "security:review" # Added for security-related updates
     
     # Configure versioning strategy
     versioning-strategy: auto


### PR DESCRIPTION
This pull request makes minor updates to the `.github/dependabot.yml` file, primarily focused on refining the configuration for reviewers and labels.

Changes to reviewers:

* Removed the optional team reviewer `team:frontend-devs` from the `reviewers` section.

Changes to labels:

* Removed the `security:review` label from the `labels` section, which was previously used for security-related updates.