### PR TITLE
Add CODEOWNERS file and streamline dependabot configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Source: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @ken-guru will be requested for
+# review when someone opens a pull request.
+*       @ken-guru

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
       time: "09:00" # Optional: Set specific time (UTC)
     open-pull-requests-limit: 15 # Increased from 10 to accommodate security updates
     target-branch: "main" # Specify target branch explicitly
-    reviewers:
-      - "ken-guru"
     assignees:
       - "ken-guru" # Add assignees for better tracking
     # Enabled security updates  
@@ -142,8 +140,6 @@ updates:
       day: "wednesday" # Staggered from npm updates
       time: "09:00"
     open-pull-requests-limit: 10
-    reviewers:
-      - "ken-guru"
     labels:
       - "ci-cd"
       - "dependencies"


### PR DESCRIPTION
Create a CODEOWNERS file to define default ownership for pull requests and remove the 'reviewers' field from the dependabot configuration to simplify the setup.