### PR TITLE
Potential fix for code scanning alert no. 11: Useless conditional

### DIFF
--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -46,7 +46,7 @@ export default function Timeline({ entries, totalDuration, elapsedTime: initialE
     if (!colors) return undefined;
     
     // If we already have theme-specific colors, use those directly
-    if (colors && 'light' in colors && 'dark' in colors) {
+    if ('light' in colors && 'dark' in colors) {
       return currentTheme === 'dark' ? colors.dark : colors.light;
     }
     


### PR DESCRIPTION
Potential fix for [https://github.com/ken-guru/github-copilot-agent-assisted-next-app/security/code-scanning/11](https://github.com/ken-guru/github-copilot-agent-assisted-next-app/security/code-scanning/11)

To fix the issue, the redundant `colors` check in the condition `if (colors && 'light' in colors && 'dark' in colors)` should be removed. The corrected condition will simply check `'light' in colors && 'dark' in colors`, as `colors` is guaranteed to be truthy at this point in the function. This change will eliminate the useless conditional while preserving the intended functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
