### PR TITLE
Potential fix for code scanning alert no. 10: Useless conditional

### DIFF
--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -30,7 +30,7 @@ export default function Summary({
     if (!colors) return undefined;
 
     // If we already have theme-specific colors, use those directly
-    if (colors && 'light' in colors && 'dark' in colors) {
+    if ('light' in colors && 'dark' in colors) {
       return currentTheme === 'dark' ? colors.dark : colors.light;
     }
     


### PR DESCRIPTION
Potential fix for [https://github.com/ken-guru/github-copilot-agent-assisted-next-app/security/code-scanning/10](https://github.com/ken-guru/github-copilot-agent-assisted-next-app/security/code-scanning/10)

To fix the issue, we will remove the redundant `colors` check from the condition on line 33. The updated condition will only check for `'light' in colors` and `'dark' in colors`, as these are sufficient to determine whether the `colors` object contains theme-specific color properties. This change will simplify the code and resolve the "useless conditional" error.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
