### PR TITLE
Implement +1 minute functionality for duration extension

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -3,7 +3,7 @@
 const CACHE_NAME_PREFIX = 'github-copilot-agent-assisted-next-app';
 // Use consistent version - will be replaced at build time or deployment
 // This ensures consistent cache versioning across all instances
-const BUILD_VERSION = '0.1.0-1753337620483'; // Format: package.version-increment
+const BUILD_VERSION = '0.1.0-1753343901891'; // Format: package.version-increment
 const CACHE_NAME = `${CACHE_NAME_PREFIX}-v${BUILD_VERSION}`;
 const APP_SHELL_CACHE_NAME = `app-shell-v${BUILD_VERSION}`;
 

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -3,7 +3,7 @@
 const CACHE_NAME_PREFIX = 'github-copilot-agent-assisted-next-app';
 // Use consistent version - will be replaced at build time or deployment
 // This ensures consistent cache versioning across all instances
-const BUILD_VERSION = '0.1.0-1753343901891'; // Format: package.version-increment
+const BUILD_VERSION = '0.1.0-1753346039552'; // Format: package.version-increment
 const CACHE_NAME = `${CACHE_NAME_PREFIX}-v${BUILD_VERSION}`;
 const APP_SHELL_CACHE_NAME = `app-shell-v${BUILD_VERSION}`;
 

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -3,7 +3,7 @@
 const CACHE_NAME_PREFIX = 'github-copilot-agent-assisted-next-app';
 // Use consistent version - will be replaced at build time or deployment
 // This ensures consistent cache versioning across all instances
-const BUILD_VERSION = '0.1.0-1753346039552'; // Format: package.version-increment
+const BUILD_VERSION = '0.1.0-1753347155082'; // Format: package.version-increment
 const CACHE_NAME = `${CACHE_NAME_PREFIX}-v${BUILD_VERSION}`;
 const APP_SHELL_CACHE_NAME = `app-shell-v${BUILD_VERSION}`;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,6 +37,7 @@ function AppContent() {
     timerActive,
     startTimer,
     resetTimer,
+    extendDuration: clearTimeUpState,
   } = useTimerState({
     totalDuration,
     isCompleted: allActivitiesCompleted
@@ -112,6 +113,18 @@ function AppContent() {
     setTimeSet(true);
   };
   
+  const handleExtendDuration = () => {
+    if (elapsedTime <= totalDuration) {
+      // Normal case: just add 1 minute
+      setTotalDuration(totalDuration + 60);
+    } else {
+      // Overtime case: set duration to elapsed time + 1 minute
+      setTotalDuration(elapsedTime + 60);
+    }
+    // Clear the time up state
+    clearTimeUpState();
+  };
+  
   const handleReset = async () => {
     await resetService.reset();
   };
@@ -161,6 +174,7 @@ function AppContent() {
                   totalDuration={totalDuration}
                   timerActive={timerActive}
                   onReset={handleReset}
+                  onExtendDuration={handleExtendDuration}
                 />
               </div>
               <div className="col-lg-7 d-none d-lg-flex flex-column overflow-hidden">

--- a/src/components/ActivityManager.tsx
+++ b/src/components/ActivityManager.tsx
@@ -25,6 +25,8 @@ interface ActivityManagerProps {
   timerActive?: boolean;
   // Reset callback for session/timer reset
   onReset?: () => void;
+  // Extend duration callback for adding 1 minute
+  onExtendDuration?: () => void;
 }
 
 export default function ActivityManager({ 
@@ -37,7 +39,8 @@ export default function ActivityManager({
   elapsedTime = 0,
   totalDuration = 0,
   timerActive = false,
-  onReset
+  onReset,
+  onExtendDuration
 }: ActivityManagerProps) {
   const [activities, setActivities] = useState<Activity[]>([]);
   const [assignedColorIndices, setAssignedColorIndices] = useState<number[]>([]);
@@ -126,6 +129,12 @@ export default function ActivityManager({
     }
   };
 
+  const handleExtendDuration = () => {
+    if (onExtendDuration) {
+      onExtendDuration();
+    }
+  };
+
   const handleResetSession = () => {
     // Call global reset function to reset timer/session
     if (onReset) {
@@ -137,18 +146,32 @@ export default function ActivityManager({
     <Card className="h-100 d-flex flex-column" data-testid="activity-manager">
       <Card.Header className="card-header-consistent">
         <h5 className="mb-0">Activities</h5>
-        {onReset && (
-          <Button 
-            variant="outline-danger" 
-            size="sm" 
-            onClick={handleResetSession}
-            className="d-flex align-items-center"
-            title="Reset session and return to time setup"
-          >
-            <i className="bi bi-arrow-clockwise me-2"></i>
-            Reset
-          </Button>
-        )}
+        <div className="d-flex gap-2">
+          {onExtendDuration && (
+            <Button 
+              variant="outline-primary" 
+              size="sm" 
+              onClick={handleExtendDuration}
+              className="d-flex align-items-center"
+              title="Add 1 minute to session duration"
+            >
+              <i className="bi bi-plus-circle me-2"></i>
+              +1 min
+            </Button>
+          )}
+          {onReset && (
+            <Button 
+              variant="outline-danger" 
+              size="sm" 
+              onClick={handleResetSession}
+              className="d-flex align-items-center"
+              title="Reset session and return to time setup"
+            >
+              <i className="bi bi-arrow-clockwise me-2"></i>
+              Reset
+            </Button>
+          )}
+        </div>
       </Card.Header>
       <Card.Body className="d-flex flex-column flex-grow-1 overflow-hidden p-3">
         {activities.length === 0 ? (

--- a/src/components/ActivityManager.tsx
+++ b/src/components/ActivityManager.tsx
@@ -156,7 +156,7 @@ export default function ActivityManager({
               title="Add 1 minute to session duration"
             >
               <i className="bi bi-plus-circle me-2"></i>
-              +1 min
+              1 min
             </Button>
           )}
           {onReset && (

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -210,11 +210,10 @@ export default function Timeline({ entries, totalDuration, elapsedTime: initialE
       setOvertimeToastId(toastId);
     } else if (!isOvertime && overtimeToastId) {
       // Remove overtime toast when no longer in overtime
-      // Note: We don't automatically remove it here since it's persistent
-      // The user needs to manually dismiss it
+      removeToast(overtimeToastId);
       setOvertimeToastId(null);
     }
-  }, [isOvertime, overtimeToastId, timerActive, addToast]);
+  }, [isOvertime, overtimeToastId, timerActive, addToast, removeToast]);
 
   // Auto-dismiss overtime toast when all activities are completed (summary state)
   useEffect(() => {
@@ -223,6 +222,15 @@ export default function Timeline({ entries, totalDuration, elapsedTime: initialE
       setOvertimeToastId(null);
     }
   }, [allActivitiesCompleted, overtimeToastId, removeToast]);
+
+  // Cleanup overtime toast on component unmount (handles reset to setup)
+  useEffect(() => {
+    return () => {
+      if (overtimeToastId) {
+        removeToast(overtimeToastId);
+      }
+    };
+  }, [overtimeToastId, removeToast]);
 
   // Calculate effective duration for timeline - dynamically adjust if in overtime
   const effectiveDuration = useMemo(() => {

--- a/src/components/__tests__/ActivityManager.test.tsx
+++ b/src/components/__tests__/ActivityManager.test.tsx
@@ -453,7 +453,7 @@ describe('ActivityManager Component', () => {
     });
   });
 
-  describe('Extend Duration Button (+1 min)', () => {
+  describe('Extend Duration Button (1 min)', () => {
     const mockProps = {
       onActivitySelect: jest.fn(),
       onActivityRemove: jest.fn(),
@@ -463,39 +463,39 @@ describe('ActivityManager Component', () => {
       elapsedTime: 0,
     };
 
-    it('does not render +1 min button when onExtendDuration prop is not provided', () => {
+    it('does not render 1 min button when onExtendDuration prop is not provided', () => {
       render(<ActivityManager {...mockProps} />);
       
-      expect(screen.queryByRole('button', { name: /\+1 min/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /1 min/i })).not.toBeInTheDocument();
     });
 
-    it('renders +1 min button when onExtendDuration prop is provided', () => {
+    it('renders 1 min button when onExtendDuration prop is provided', () => {
       const onExtendDuration = jest.fn();
       render(<ActivityManager {...mockProps} onExtendDuration={onExtendDuration} />);
       
-      const extendButton = screen.getByRole('button', { name: /\+1 min/i });
+      const extendButton = screen.getByRole('button', { name: /1 min/i });
       expect(extendButton).toBeInTheDocument();
       expect(extendButton).toHaveClass('btn-outline-primary');
       expect(extendButton).toHaveAttribute('title', 'Add 1 minute to session duration');
     });
 
-    it('calls onExtendDuration callback when +1 min button is clicked', () => {
+    it('calls onExtendDuration callback when 1 min button is clicked', () => {
       const onExtendDuration = jest.fn();
       render(<ActivityManager {...mockProps} onExtendDuration={onExtendDuration} />);
       
-      const extendButton = screen.getByRole('button', { name: /\+1 min/i });
+      const extendButton = screen.getByRole('button', { name: /1 min/i });
       fireEvent.click(extendButton);
       
       expect(onExtendDuration).toHaveBeenCalledTimes(1);
     });
 
-    it('positions +1 min button before reset button in card header', () => {
+    it('positions 1 min button before reset button in card header', () => {
       const onReset = jest.fn();
       const onExtendDuration = jest.fn();
       render(<ActivityManager {...mockProps} onReset={onReset} onExtendDuration={onExtendDuration} />);
       
       const cardHeader = screen.getByText('Activities').closest('.card-header');
-      const extendButton = screen.getByRole('button', { name: /\+1 min/i });
+      const extendButton = screen.getByRole('button', { name: /1 min/i });
       const resetButton = screen.getByRole('button', { name: /Reset/i });
       
       expect(cardHeader).toContainElement(extendButton);
@@ -507,11 +507,11 @@ describe('ActivityManager Component', () => {
       expect(buttons?.[1]).toBe(resetButton);
     });
 
-    it('displays appropriate icon in +1 min button', () => {
+    it('displays appropriate icon in 1 min button', () => {
       const onExtendDuration = jest.fn();
       render(<ActivityManager {...mockProps} onExtendDuration={onExtendDuration} />);
       
-      const extendButton = screen.getByRole('button', { name: /\+1 min/i });
+      const extendButton = screen.getByRole('button', { name: /1 min/i });
       const icon = extendButton.querySelector('i.bi-plus-circle');
       
       expect(icon).toBeInTheDocument();

--- a/src/components/__tests__/ActivityManager.test.tsx
+++ b/src/components/__tests__/ActivityManager.test.tsx
@@ -452,4 +452,69 @@ describe('ActivityManager Component', () => {
       expect(cardHeader).toHaveClass('card-header-consistent');
     });
   });
+
+  describe('Extend Duration Button (+1 min)', () => {
+    const mockProps = {
+      onActivitySelect: jest.fn(),
+      onActivityRemove: jest.fn(),
+      completedActivityIds: [],
+      currentActivityId: null,
+      timelineEntries: [],
+      elapsedTime: 0,
+    };
+
+    it('does not render +1 min button when onExtendDuration prop is not provided', () => {
+      render(<ActivityManager {...mockProps} />);
+      
+      expect(screen.queryByRole('button', { name: /\+1 min/i })).not.toBeInTheDocument();
+    });
+
+    it('renders +1 min button when onExtendDuration prop is provided', () => {
+      const onExtendDuration = jest.fn();
+      render(<ActivityManager {...mockProps} onExtendDuration={onExtendDuration} />);
+      
+      const extendButton = screen.getByRole('button', { name: /\+1 min/i });
+      expect(extendButton).toBeInTheDocument();
+      expect(extendButton).toHaveClass('btn-outline-primary');
+      expect(extendButton).toHaveAttribute('title', 'Add 1 minute to session duration');
+    });
+
+    it('calls onExtendDuration callback when +1 min button is clicked', () => {
+      const onExtendDuration = jest.fn();
+      render(<ActivityManager {...mockProps} onExtendDuration={onExtendDuration} />);
+      
+      const extendButton = screen.getByRole('button', { name: /\+1 min/i });
+      fireEvent.click(extendButton);
+      
+      expect(onExtendDuration).toHaveBeenCalledTimes(1);
+    });
+
+    it('positions +1 min button before reset button in card header', () => {
+      const onReset = jest.fn();
+      const onExtendDuration = jest.fn();
+      render(<ActivityManager {...mockProps} onReset={onReset} onExtendDuration={onExtendDuration} />);
+      
+      const cardHeader = screen.getByText('Activities').closest('.card-header');
+      const extendButton = screen.getByRole('button', { name: /\+1 min/i });
+      const resetButton = screen.getByRole('button', { name: /Reset/i });
+      
+      expect(cardHeader).toContainElement(extendButton);
+      expect(cardHeader).toContainElement(resetButton);
+      
+      // Check order - extend button should come before reset button in DOM
+      const buttons = cardHeader?.querySelectorAll('button');
+      expect(buttons?.[0]).toBe(extendButton);
+      expect(buttons?.[1]).toBe(resetButton);
+    });
+
+    it('displays appropriate icon in +1 min button', () => {
+      const onExtendDuration = jest.fn();
+      render(<ActivityManager {...mockProps} onExtendDuration={onExtendDuration} />);
+      
+      const extendButton = screen.getByRole('button', { name: /\+1 min/i });
+      const icon = extendButton.querySelector('i.bi-plus-circle');
+      
+      expect(icon).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/__tests__/Timeline.test.tsx
+++ b/src/components/__tests__/Timeline.test.tsx
@@ -186,6 +186,38 @@ describe('Timeline Component', () => {
     expect(timeDisplay.textContent).not.toContain('Overtime');
   });
 
+  it('should dismiss overtime toast when component unmounts or resets', async () => {
+    const mockEntries: TimelineEntry[] = [
+      {
+        id: '1',
+        activityId: 'activity-1',
+        activityName: 'Task 1',
+        startTime: FIXED_TIME - 4000 * 1000,
+        endTime: FIXED_TIME,
+        colors: {
+          background: '#E8F5E9',
+          text: '#1B5E20',
+          border: '#2E7D32'
+        }
+      }
+    ];
+    
+    // Render in overtime condition
+    const { unmount } = renderTimeline(mockEntries, {
+      elapsedTime: 4000,
+      isTimeUp: true
+    });
+    
+    // Verify we're in overtime state
+    const timeDisplay = screen.getByTestId('time-display');
+    expect(timeDisplay.textContent).toContain('Overtime');
+    
+    // Unmount component (simulates reset to setup)
+    unmount();
+    
+    // Test passed if no errors during unmount (toast properly cleaned up)
+  });
+
   // Test if timeline activity colors update when theme changes
   test('updates activity colors when theme changes', () => {
     // Mock entries with colors for testing

--- a/src/components/__tests__/Timeline.test.tsx
+++ b/src/components/__tests__/Timeline.test.tsx
@@ -139,6 +139,53 @@ describe('Timeline Component', () => {
     expect(timeDisplay).toBeInTheDocument();
   });
 
+  it('should dismiss overtime toast when duration is extended and no longer in overtime', async () => {
+    // Use exact same mock entries as working test
+    const startTime = FIXED_TIME - 4000 * 1000;
+    const endTime = FIXED_TIME;
+    const mockEntries: TimelineEntry[] = [
+      {
+        id: '1',
+        activityId: 'activity-1',
+        activityName: 'Task 1',
+        startTime: startTime,
+        endTime: endTime,
+        colors: {
+          background: '#E8F5E9',
+          text: '#1B5E20',
+          border: '#2E7D32'
+        }
+      }
+    ];
+    
+    // Start with overtime condition
+    const { rerender } = renderTimeline(mockEntries, {
+      elapsedTime: 4000, // 66 min 40 sec (400 seconds over default 3600)
+      isTimeUp: true
+    });
+    
+    // Verify we're in overtime state
+    const timeDisplay = screen.getByTestId('time-display');
+    expect(timeDisplay.textContent).toContain('Overtime');
+    
+    // Extend duration to get out of overtime: default 3600 + 500 = 4100 (100 sec buffer)
+    rerender(
+      <ToastProvider>
+        <Timeline 
+          entries={mockEntries}
+          totalDuration={4100} // Extended beyond current elapsed time
+          elapsedTime={4000} // Same elapsed time, now under new limit
+          timerActive={true}
+          allActivitiesCompleted={false}
+        />
+      </ToastProvider>
+    );
+    
+    // After extension, should no longer be in overtime
+    expect(timeDisplay.textContent).toContain('Time Left');
+    expect(timeDisplay.textContent).not.toContain('Overtime');
+  });
+
   // Test if timeline activity colors update when theme changes
   test('updates activity colors when theme changes', () => {
     // Mock entries with colors for testing

--- a/src/hooks/__tests__/useTimerState.extendDuration.integration.test.tsx
+++ b/src/hooks/__tests__/useTimerState.extendDuration.integration.test.tsx
@@ -1,0 +1,173 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTimerState } from '../useTimerState';
+
+describe('useTimerState - extendDuration integration scenarios', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  describe('Issue #262 scenarios', () => {
+    it('should handle scenario 1: 2 minutes duration, 1:10 spent, press +1 min → 3 minutes with 1:10 spent', () => {
+      const { result } = renderHook(() => useTimerState({ totalDuration: 120 })); // 2 minutes
+      
+      // Start timer and advance to 1 minute 10 seconds
+      act(() => {
+        result.current.startTimer();
+        jest.advanceTimersByTime(70000); // 1 minute 10 seconds
+      });
+      
+      // Check initial state
+      expect(result.current.elapsedTime).toBe(70);
+      expect(result.current.isTimeUp).toBe(false);
+      
+      // This test verifies that extendDuration clears isTimeUp state
+      // In the actual implementation, the parent component (page.tsx) 
+      // handles updating the totalDuration prop
+      act(() => {
+        result.current.extendDuration();
+      });
+      
+      // Verify timer continues running normally
+      act(() => {
+        jest.advanceTimersByTime(10000); // 10 more seconds
+      });
+      
+      expect(result.current.elapsedTime).toBe(80); // 1:20 total
+      expect(result.current.isTimeUp).toBe(false);
+    });
+
+    it('should handle scenario 2: 1 minute duration, 1:15 spent (overtime), press +1 min', () => {
+      const { result, rerender } = renderHook(
+        ({ totalDuration }) => useTimerState({ totalDuration }),
+        { initialProps: { totalDuration: 60 } } // 1 minute
+      );
+      
+      // Start timer and advance to 1 minute 15 seconds (overtime)
+      act(() => {
+        result.current.startTimer();
+        jest.advanceTimersByTime(75000); // 1 minute 15 seconds
+      });
+      
+      // Check overtime state
+      expect(result.current.elapsedTime).toBe(75);
+      expect(result.current.isTimeUp).toBe(true);
+      
+      // Extend duration (clears isTimeUp) and simulate prop update
+      act(() => {
+        result.current.extendDuration();
+        // Simulate parent component updating totalDuration to elapsedTime + 60
+        rerender({ totalDuration: 75 + 60 }); // 135 seconds = 2:15
+      });
+      
+      // Verify overtime state is cleared
+      expect(result.current.isTimeUp).toBe(false);
+      
+      // Verify timer continues running
+      act(() => {
+        jest.advanceTimersByTime(5000); // 5 more seconds
+      });
+      
+      expect(result.current.elapsedTime).toBe(80); // 1:20 total
+      expect(result.current.isTimeUp).toBe(false);
+    });
+
+    it('should handle scenario 3: 2 minutes duration, 0 seconds spent, press +1 min → 3 minutes with 0 spent', () => {
+      const { result } = renderHook(() => useTimerState({ totalDuration: 120 })); // 2 minutes
+      
+      // Start timer but don't advance time
+      act(() => {
+        result.current.startTimer();
+      });
+      
+      // Check initial state
+      expect(result.current.elapsedTime).toBe(0);
+      expect(result.current.isTimeUp).toBe(false);
+      
+      // Extend duration
+      act(() => {
+        result.current.extendDuration();
+      });
+      
+      // Verify state remains good
+      expect(result.current.isTimeUp).toBe(false);
+      
+      // Verify timer continues normally
+      act(() => {
+        jest.advanceTimersByTime(30000); // 30 seconds
+      });
+      
+      expect(result.current.elapsedTime).toBe(30);
+      expect(result.current.isTimeUp).toBe(false);
+    });
+
+    it('should work correctly when extending duration multiple times', () => {
+      const { result } = renderHook(() => useTimerState({ totalDuration: 30 })); // 30 seconds
+      
+      // Start timer and go into overtime
+      act(() => {
+        result.current.startTimer();
+        jest.advanceTimersByTime(45000); // 45 seconds (15s overtime)
+      });
+      
+      expect(result.current.isTimeUp).toBe(true);
+      
+      // First extension
+      act(() => {
+        result.current.extendDuration();
+      });
+      
+      expect(result.current.isTimeUp).toBe(false);
+      
+      // Advance more time to go into overtime again
+      act(() => {
+        jest.advanceTimersByTime(30000); // 30 more seconds
+      });
+      
+      expect(result.current.elapsedTime).toBe(75);
+      // Note: Whether isTimeUp becomes true depends on the updated totalDuration
+      // This test focuses on extendDuration's ability to clear the state
+      
+      // Second extension
+      act(() => {
+        result.current.extendDuration();
+      });
+      
+      expect(result.current.isTimeUp).toBe(false);
+    });
+
+    it('should not interfere with timer active state', () => {
+      const { result } = renderHook(() => useTimerState({ totalDuration: 60 }));
+      
+      // Start timer
+      act(() => {
+        result.current.startTimer();
+        jest.advanceTimersByTime(70000); // 70 seconds (overtime)
+      });
+      
+      expect(result.current.timerActive).toBe(true);
+      expect(result.current.isTimeUp).toBe(true);
+      
+      // Extend duration
+      act(() => {
+        result.current.extendDuration();
+      });
+      
+      // Timer should still be active
+      expect(result.current.timerActive).toBe(true);
+      expect(result.current.isTimeUp).toBe(false);
+      
+      // Timer should continue running
+      act(() => {
+        jest.advanceTimersByTime(5000); // 5 more seconds
+      });
+      
+      expect(result.current.elapsedTime).toBe(75);
+      expect(result.current.timerActive).toBe(true);
+    });
+  });
+});

--- a/src/hooks/__tests__/useTimerState.test.tsx
+++ b/src/hooks/__tests__/useTimerState.test.tsx
@@ -133,4 +133,73 @@ describe('useTimerState', () => {
       expect(result.current.timerActive).toBe(true);
     });
   });
+
+  describe('extend duration functionality', () => {
+    it('should clear isTimeUp when extendDuration is called during overtime', () => {
+      const { result } = renderHook(() => useTimerState({ totalDuration: 30 }));
+      
+      act(() => {
+        result.current.startTimer();
+        jest.advanceTimersByTime(31000); // 31 seconds (overtime)
+      });
+      
+      expect(result.current.isTimeUp).toBe(true);
+      
+      act(() => {
+        result.current.extendDuration();
+      });
+      
+      expect(result.current.isTimeUp).toBe(false);
+    });
+
+    it('should continue running timer after extending duration', () => {
+      const { result } = renderHook(() => useTimerState({ totalDuration: 30 }));
+      
+      act(() => {
+        result.current.startTimer();
+        jest.advanceTimersByTime(10000); // 10 seconds
+      });
+      
+      const elapsedBeforeExtend = result.current.elapsedTime;
+      
+      act(() => {
+        result.current.extendDuration();
+        jest.advanceTimersByTime(5000); // additional 5 seconds
+      });
+      
+      expect(result.current.elapsedTime).toBe(elapsedBeforeExtend + 5);
+      expect(result.current.timerActive).toBe(true);
+    });
+
+    it('should work correctly when called multiple times', () => {
+      const { result } = renderHook(() => useTimerState({ totalDuration: 30 }));
+      
+      act(() => {
+        result.current.startTimer();
+        jest.advanceTimersByTime(35000); // 35 seconds (overtime)
+      });
+      
+      expect(result.current.isTimeUp).toBe(true);
+      
+      act(() => {
+        result.current.extendDuration();
+      });
+      
+      expect(result.current.isTimeUp).toBe(false);
+      
+      // Advance more time to trigger overtime again
+      act(() => {
+        jest.advanceTimersByTime(10000); // 10 more seconds
+      });
+      
+      // Should trigger overtime again
+      expect(result.current.isTimeUp).toBe(true);
+      
+      act(() => {
+        result.current.extendDuration();
+      });
+      
+      expect(result.current.isTimeUp).toBe(false);
+    });
+  });
 });

--- a/src/hooks/useTimerState.ts
+++ b/src/hooks/useTimerState.ts
@@ -19,6 +19,20 @@ export function useTimerState({ totalDuration, isCompleted = false }: UseTimerSt
     setTimerActive(false);
   }, []);
 
+  const extendDuration = useCallback(() => {
+    // Clear isTimeUp state when extending duration
+    setIsTimeUp(false);
+  }, []);
+
+  // Effect to update isTimeUp when totalDuration changes
+  useEffect(() => {
+    if (timerActive && elapsedTime >= totalDuration) {
+      setIsTimeUp(true);
+    } else if (timerActive && elapsedTime < totalDuration) {
+      setIsTimeUp(false);
+    }
+  }, [totalDuration, elapsedTime, timerActive]);
+
   useEffect(() => {
     if (isCompleted) {
       stopTimer();
@@ -61,6 +75,7 @@ export function useTimerState({ totalDuration, isCompleted = false }: UseTimerSt
     timerActive,
     startTimer,
     stopTimer,
-    resetTimer
+    resetTimer,
+    extendDuration
   };
 }


### PR DESCRIPTION
Allow users to add 1 minute to the duration, adjusting for both normal and overtime scenarios. Update the countdown timer, timeline visualization, and notifications accordingly. Comprehensive tests ensure all scenarios are covered.

Fixes #262