### PR TITLE
Fix #308: Show Import and Reset in empty Activity CRUD state

### DIFF
--- a/cypress/e2e/activity-crud.cy.ts
+++ b/cypress/e2e/activity-crud.cy.ts
@@ -34,10 +34,10 @@ describe('Activity CRUD Operations', () => {
       cy.contains('Your Activities').should('be.visible');
       cy.contains('Add Activity').should('be.visible');
       
-  // Verify essential UI elements in empty state
+  // Verify essential UI elements with default activities present
   cy.get('button').contains('Import').should('be.visible');
+  cy.get('button').contains('Export').should('be.visible');
   cy.get('button').contains('Reset Activities').should('be.visible');
-  cy.get('button').contains('Export').should('not.exist');
       
       // This is a high-level smoke test - detailed CRUD testing should be in Jest
     });
@@ -121,15 +121,18 @@ describe('Activity CRUD Operations', () => {
 
   describe('Error Handling Integration', () => {
     it('should handle empty activity list gracefully', () => {
-      // Ensure clean state
+      // Force empty state: set activities array to empty and reload
       cy.window().then((win) => {
-        win.localStorage.clear();
+        win.localStorage.setItem('activities_v1', '[]');
       });
       cy.reload();
-      
-      // Should show empty state
-  cy.contains('No activities found').should('be.visible');
+
+      // Should show empty state with toolbar actions available (except Export)
+      cy.contains('No activities found').should('be.visible');
       cy.get('button').contains('Add Activity').should('be.visible');
+      cy.get('button').contains('Import').should('be.visible');
+      cy.get('button').contains('Reset Activities').should('be.visible');
+      cy.get('button').contains('Export').should('not.exist');
     });
 
     it('should handle modal interactions correctly', () => {

--- a/cypress/e2e/activity-crud.cy.ts
+++ b/cypress/e2e/activity-crud.cy.ts
@@ -34,9 +34,10 @@ describe('Activity CRUD Operations', () => {
       cy.contains('Your Activities').should('be.visible');
       cy.contains('Add Activity').should('be.visible');
       
-      // Verify essential UI elements are present
-      cy.get('button').contains('Import').should('be.visible');
-      cy.get('button').contains('Export').should('be.visible');
+  // Verify essential UI elements in empty state
+  cy.get('button').contains('Import').should('be.visible');
+  cy.get('button').contains('Reset Activities').should('be.visible');
+  cy.get('button').contains('Export').should('not.exist');
       
       // This is a high-level smoke test - detailed CRUD testing should be in Jest
     });
@@ -127,7 +128,7 @@ describe('Activity CRUD Operations', () => {
       cy.reload();
       
       // Should show empty state
-      cy.contains('No activities yet').should('be.visible');
+  cy.contains('No activities found').should('be.visible');
       cy.get('button').contains('Add Activity').should('be.visible');
     });
 

--- a/docs/PLANNED_CHANGES.md
+++ b/docs/PLANNED_CHANGES.md
@@ -4,6 +4,25 @@ This file contains specifications for upcoming changes to the application. Each 
 
 Once implemented, move the change to `IMPLEMENTED_CHANGES.md` with a timestamp.
 
+## Issue #308: Activity CRUD Empty State Toolbar (IMPLEMENTED ✅)
+
+### Context
+- Users couldn't access Import JSON and Reset actions when the activities list was empty.
+- Request: Keep the "Your Activities" card visible in empty state and surface Import/Reset there; hide Export when no activities exist.
+
+### Implementation Summary
+- Always render `ActivityList` from `ActivityCrud` regardless of list length.
+- In `ActivityList` empty state:
+   - Keep header with "Add Activity" button.
+   - Show empty-state guidance in `Card.Body`.
+   - Render `Card.Footer` with Import and Reset buttons when handlers are provided.
+   - Do not render Export button when `activities.length === 0`.
+- Tests updated to validate visibility of Import/Reset in empty state and absence of Export.
+
+### Status
+- Implemented on branch `fix-308-activitycrud-empty-state`.
+- PR opened: #317.
+
 ## UI Inconsistencies Fixes (Issues #261, #265)
 
 ### Context

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -11,7 +11,7 @@ try {
 const CACHE_NAME_PREFIX = 'github-copilot-agent-assisted-next-app';
 // Use consistent version - will be replaced at build time or deployment
 // This ensures consistent cache versioning across all instances
-const BUILD_VERSION = '0.1.0-1755082179313'; // Format: package.version-increment
+const BUILD_VERSION = '0.1.0-1755090579761'; // Format: package.version-increment
 const CACHE_NAME = `${CACHE_NAME_PREFIX}-v${BUILD_VERSION}`;
 const APP_SHELL_CACHE_NAME = `app-shell-v${BUILD_VERSION}`;
 

--- a/src/components/__tests__/ActivityList.test.tsx
+++ b/src/components/__tests__/ActivityList.test.tsx
@@ -48,6 +48,28 @@ describe('ActivityList', () => {
     expect(screen.getByText(/No activities found/i)).toBeInTheDocument();
   });
 
+  it('shows import and reset buttons in empty state when handlers provided, hides export', () => {
+    const onImport = jest.fn();
+    const onReset = jest.fn();
+    const onExport = jest.fn();
+
+    render(
+      <ActivityList 
+        activities={[]} 
+        onImport={onImport} 
+        onReset={onReset}
+        onExport={onExport}
+      />
+    );
+
+    // Import and Reset should be visible
+    expect(screen.getByRole('button', { name: /Import/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Reset Activities/i })).toBeInTheDocument();
+
+    // Export should be hidden when there are no activities
+    expect(screen.queryByRole('button', { name: /Export/i })).not.toBeInTheDocument();
+  });
+
   describe('Footer Toolbar', () => {
     it('does not render footer when no action props are provided', () => {
       render(<ActivityList activities={DEFAULT_ACTIVITIES} />);

--- a/src/components/feature/ActivityCrud.tsx
+++ b/src/components/feature/ActivityCrud.tsx
@@ -272,29 +272,15 @@ const ActivityCrud: React.FC = () => {
       {/* Activities List Section */}
       <div className="row">
         <div className="col-12">
-          {activities.length === 0 ? (
-            <div className="text-center py-5">
-              <div className="mb-3">
-                <i className="bi bi-list-task" style={{fontSize: '3rem'}} aria-hidden="true"></i>
-              </div>
-              <h4 className="text-muted">No activities yet</h4>
-              <p className="text-muted">Get started by creating your first activity</p>
-              <Button variant="primary" onClick={handleAdd} className="d-flex align-items-center mx-auto">
-                <i className="bi bi-plus me-2"></i>
-                Create First Activity
-              </Button>
-            </div>
-          ) : (
-            <ActivityList
-              activities={activities}
-              onEdit={handleEdit}
-              onDelete={handleDelete}
-              onAdd={handleAdd}
-              onImport={handleImport}
-              onExport={handleExport}
-              onReset={handleResetToDefault}
-            />
-          )}
+          <ActivityList
+            activities={activities}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            onAdd={handleAdd}
+            onImport={handleImport}
+            onExport={handleExport}
+            onReset={handleResetToDefault}
+          />
         </div>
       </div>
 

--- a/src/components/feature/ActivityList.tsx
+++ b/src/components/feature/ActivityList.tsx
@@ -37,9 +37,40 @@ const ActivityList: React.FC<ActivityListProps> = ({ activities, onEdit, onDelet
             <div className="text-muted">
               <i className="bi bi-kanban fa-2x mb-3"></i>
               <p>No activities found</p>
+              <p className="mb-0 small">You can import a JSON file or reset to defaults to get started.</p>
             </div>
           </div>
         </Card.Body>
+        {(onImport || onReset) && (
+          <Card.Footer className={theme === 'dark' ? 'bg-dark text-light' : 'bg-light'}>
+            <div className="d-flex gap-2 justify-content-center">
+              {onImport && (
+                <Button 
+                  variant="outline-secondary" 
+                  size="sm" 
+                  onClick={onImport}
+                  className="d-flex align-items-center px-3"
+                  title="Import activities from JSON file"
+                >
+                  <i className="bi bi-upload me-2"></i>
+                  Import
+                </Button>
+              )}
+              {onReset && (
+                <Button 
+                  variant="outline-danger" 
+                  size="sm" 
+                  onClick={onReset}
+                  className="d-flex align-items-center px-3"
+                  title="Reset to default activities"
+                >
+                  <i className="bi bi-arrow-clockwise me-2"></i>
+                  Reset Activities
+                </Button>
+              )}
+            </div>
+          </Card.Footer>
+        )}
       </Card>
     );
   }


### PR DESCRIPTION
## Problem
When there are no activities, users cannot access the Import JSON and Reset buttons because the actions only appear when the list has items.

## Solution
- Always render the "Your Activities" card via ActivityList, even when the list is empty
- In the empty state body, show brief guidance
- In the card footer, render Import and Reset buttons when handlers are provided
- Keep Export hidden when there are no activities (still available when activities exist)
- Preserve Add Activity action in the card header

## Files Changed
- src/components/feature/ActivityCrud.tsx: Always render ActivityList (removes bespoke empty-state block)
- src/components/feature/ActivityList.tsx: Adds footer in empty state with Import and Reset; hides Export when empty
- src/components/__tests__/ActivityList.test.tsx: Adds tests to verify toolbar visibility rules in empty state

## Testing
- Jest: All tests pass locally
- Added a new test to ensure Import and Reset are present in empty state and Export is hidden

## Notes
- This preserves consistent UI and makes critical actions accessible even before any manual activity creation

Fixes #308