### PR TITLE
fix(resume): restore previous session state; persist in localStorage (fixes #343)

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -11,7 +11,7 @@ try {
 const CACHE_NAME_PREFIX = 'github-copilot-agent-assisted-next-app';
 // Use consistent version - will be replaced at build time or deployment
 // This ensures consistent cache versioning across all instances
-const BUILD_VERSION = '0.1.0-1755782958356'; // Format: package.version-increment
+const BUILD_VERSION = '0.1.0-1755806980974'; // Format: package.version-increment
 const CACHE_NAME = `${CACHE_NAME_PREFIX}-v${BUILD_VERSION}`;
 const APP_SHELL_CACHE_NAME = `app-shell-v${BUILD_VERSION}`;
 

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -6,6 +6,7 @@ import resetService, { DialogCallback } from '@/utils/resetService';
 import { ForwardRefExoticComponent, RefAttributes } from 'react';
 import { ConfirmationDialogProps, ConfirmationDialogRef } from '@/components/ConfirmationDialog';
 import { LoadingProvider } from '@/contexts/LoadingContext';
+import { SESSION_STORAGE_KEY } from '@/utils/session-storage';
 import { ToastProvider } from '@/contexts/ToastContext';
 
 // Store dialog props for testing
@@ -151,6 +152,13 @@ describe('Home Page', () => {
       onConfirm: jest.fn(),
       onCancel: jest.fn()
     };
+
+    // Ensure no persisted session interferes with initial setup expectations
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(SESSION_STORAGE_KEY);
+      }
+    } catch {}
   });
 
   it('should not show reset button in setup state', () => {
@@ -214,7 +222,7 @@ describe('Home Page', () => {
       // Start the dialog callback process in an act block
       await act(async () => {
         // The dialog callback returns a promise that resolves when user confirms/cancels
-        dialogCallback('Test message').then(result => {
+  dialogCallback('Test message').then((result: boolean) => {
           resolveCallback(result);
         });
       });
@@ -257,6 +265,12 @@ describe('Home Page', () => {
 describe('Progress Element Visibility', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Ensure no persisted session interferes with these tests' setup
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(SESSION_STORAGE_KEY);
+      }
+    } catch {}
   });
   
   it('should show progress container in activity state', () => {

--- a/src/components/__tests__/ShareControls.preserve-session.test.tsx
+++ b/src/components/__tests__/ShareControls.preserve-session.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ShareControls from '../ShareControls';
+import { SESSION_STORAGE_KEY } from '../../utils/session-storage';
+
+// Mock Next.js router
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+// Ensure localStorage is available and controllable
+beforeEach(() => {
+  // Setup a session snapshot to simulate an in-progress session
+  const snapshot = {
+    timeSet: true,
+    totalDuration: 1800,
+    timerActive: true,
+    currentActivityId: 'a1',
+    timelineEntries: [
+      { id: 't1', activityId: 'a1', activityName: 'Reading', startTime: 0, endTime: null },
+    ],
+  };
+  window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(snapshot));
+});
+
+afterEach(() => {
+  window.localStorage.removeItem(SESSION_STORAGE_KEY);
+  jest.resetAllMocks();
+});
+
+describe('ShareControls replace preserves session_v1', () => {
+  it('does not clear session snapshot on replace', async () => {
+    const shareUrl = 'https://example.com/shared/keep-123';
+    // Mock fetch to return a minimal valid shared session
+    const sample = {
+      sessionData: {
+        activities: [
+          { id: 'a2', name: 'Homework', colorIndex: 0 },
+        ],
+        skippedActivities: [],
+      },
+      metadata: { id: 'keep-123' },
+    };
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => sample } as unknown as Response);
+
+    render(<ShareControls shareUrl={shareUrl} />);
+
+    // Trigger replace flow
+    const replaceBtn = screen.getByRole('button', { name: /replace my activities/i });
+    fireEvent.click(replaceBtn);
+    const confirmButton = await screen.findByRole('button', { name: /confirm/i });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+    // Verify session snapshot still exists
+    const persisted = window.localStorage.getItem(SESSION_STORAGE_KEY);
+    expect(persisted).toBeTruthy();
+    const parsed = persisted ? JSON.parse(persisted) : null;
+    expect(parsed?.timeSet).toBe(true);
+  });
+});

--- a/src/hooks/useActivityState.ts
+++ b/src/hooks/useActivityState.ts
@@ -40,7 +40,7 @@ export function useActivityState({ onTimerStart }: UseActivityStateProps = {}) {
     timelineEntries,
     addTimelineEntry,
     completeCurrentTimelineEntry,
-    resetTimelineEntries
+  resetTimelineEntries
   } = useTimelineEntries();
 
   const handleActivitySelect = useCallback((activity: Activity | null, justAdd: boolean = false) => {
@@ -164,6 +164,6 @@ export function useActivityState({ onTimerStart }: UseActivityStateProps = {}) {
     // New method to get current activity state
     getCurrentActivityStateDetails,
     // Method to get state of a specific activity
-    getActivityState
+  getActivityState
   };
 }

--- a/src/utils/session-storage.test.ts
+++ b/src/utils/session-storage.test.ts
@@ -1,0 +1,82 @@
+import { saveSessionSnapshot, loadSessionSnapshot, clearSessionSnapshot, SESSION_STORAGE_KEY } from './session-storage';
+
+// Keep a reference to the original localStorage to restore after tests
+const originalLocalStorage = globalThis.localStorage;
+
+describe('session-storage', () => {
+  let store: Map<string, string>;
+  beforeEach(() => {
+    store = new Map<string, string>();
+    const mockStorage: Storage = {
+      get length() { return store.size; },
+      clear: () => store.clear(),
+      getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+      key: (index: number) => Array.from(store.keys())[index] ?? null,
+      removeItem: (key: string) => { store.delete(key); },
+      setItem: (key: string, value: string) => { store.set(key, value); }
+    } as unknown as Storage;
+
+    // Define localStorage on globalThis to avoid assigning to read-only property
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: mockStorage,
+      configurable: true,
+      writable: false
+    });
+  });
+
+  afterEach(() => {
+    // Restore the original localStorage after each test to avoid cross-test leakage
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: originalLocalStorage,
+      configurable: true,
+      writable: false
+    });
+  });
+
+  it('roundtrips a valid snapshot', () => {
+    const snapshot = {
+      timeSet: true,
+      totalDuration: 3600,
+      timerActive: true,
+      currentActivityId: 'a1',
+      timelineEntries: [
+  { id: 'e1', activityId: 'a1', activityName: 'Task', startTime: 100, endTime: null, colors: { background: '#fff', text: '#000', border: '#00000033' } }
+      ]
+    };
+
+    saveSessionSnapshot(snapshot);
+    const loaded = loadSessionSnapshot();
+    expect(loaded).toEqual(snapshot);
+  });
+
+  it('handles missing storage gracefully', () => {
+    // Simulate missing localStorage by redefining it as undefined
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: undefined,
+      configurable: true
+    });
+
+    expect(loadSessionSnapshot()).toBeNull();
+    expect(() =>
+      saveSessionSnapshot({ timeSet: false, totalDuration: 0, timerActive: false, currentActivityId: null, timelineEntries: [] })
+    ).not.toThrow();
+  });
+
+  it('clear removes the snapshot', () => {
+    saveSessionSnapshot({ timeSet: true, totalDuration: 60, timerActive: false, currentActivityId: null, timelineEntries: []});
+    expect(loadSessionSnapshot()).not.toBeNull();
+    clearSessionSnapshot();
+    expect(loadSessionSnapshot()).toBeNull();
+  });
+
+  it('ignores corrupted JSON', () => {
+    localStorage.setItem(SESSION_STORAGE_KEY, '{ not json');
+    expect(loadSessionSnapshot()).toBeNull();
+  });
+
+  it('sanitizes unexpected shapes', () => {
+    // store something not matching expected shape
+    localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify({ foo: 'bar', timeSet: 'yes' }));
+    expect(loadSessionSnapshot()).toBeNull();
+  });
+});

--- a/src/utils/session-storage.ts
+++ b/src/utils/session-storage.ts
@@ -27,13 +27,16 @@ function isTimelineEntry(v: unknown): v is TimelineEntry {
 
 function isValidSnapshot(v: unknown): v is SessionSnapshot {
   if (!isObject(v)) return false;
-  return (
-    typeof v.timeSet === 'boolean' &&
-    typeof v.totalDuration === 'number' &&
-    typeof v.timerActive === 'boolean' &&
-    ('currentActivityId' in v) && (typeof (v as any).currentActivityId === 'string' || (v as any).currentActivityId === null) &&
-    Array.isArray((v as any).timelineEntries) && (v as any).timelineEntries.every(isTimelineEntry)
-  );
+  const obj = v as Record<string, unknown>;
+  const timeSetOk = typeof obj.timeSet === 'boolean';
+  const totalDurationOk = typeof obj.totalDuration === 'number';
+  const timerActiveOk = typeof obj.timerActive === 'boolean';
+  const currentActivityId = (obj as { currentActivityId?: unknown }).currentActivityId;
+  const currentActivityIdOk =
+    currentActivityId === null || typeof currentActivityId === 'string';
+  const entries = (obj as { timelineEntries?: unknown }).timelineEntries;
+  const entriesOk = Array.isArray(entries) && (entries as unknown[]).every(isTimelineEntry);
+  return timeSetOk && totalDurationOk && timerActiveOk && currentActivityIdOk && entriesOk;
 }
 
 export function loadSessionSnapshot(): SessionSnapshot | null {

--- a/src/utils/session-storage.ts
+++ b/src/utils/session-storage.ts
@@ -1,0 +1,68 @@
+import type { TimelineEntry } from '@/types';
+
+export const SESSION_STORAGE_KEY = 'session_v1';
+
+export interface SessionSnapshot {
+  timeSet: boolean;
+  totalDuration: number; // seconds
+  timerActive: boolean;
+  currentActivityId: string | null;
+  timelineEntries: TimelineEntry[]; // minimal shape needed to rehydrate
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object';
+}
+
+function isTimelineEntry(v: unknown): v is TimelineEntry {
+  if (!isObject(v)) return false;
+  return (
+    typeof v.id === 'string' &&
+    (typeof v.activityId === 'string' || v.activityId === null) &&
+    (typeof v.activityName === 'string' || v.activityName === null) &&
+    typeof v.startTime === 'number' &&
+    (typeof v.endTime === 'number' || v.endTime === null)
+  );
+}
+
+function isValidSnapshot(v: unknown): v is SessionSnapshot {
+  if (!isObject(v)) return false;
+  return (
+    typeof v.timeSet === 'boolean' &&
+    typeof v.totalDuration === 'number' &&
+    typeof v.timerActive === 'boolean' &&
+    ('currentActivityId' in v) && (typeof (v as any).currentActivityId === 'string' || (v as any).currentActivityId === null) &&
+    Array.isArray((v as any).timelineEntries) && (v as any).timelineEntries.every(isTimelineEntry)
+  );
+}
+
+export function loadSessionSnapshot(): SessionSnapshot | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem(SESSION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (isValidSnapshot(parsed)) return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSessionSnapshot(snapshot: SessionSnapshot): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(snapshot));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+export function clearSessionSnapshot(): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.removeItem(SESSION_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
Fixes #343.

Summary:
- Add `session_v1` snapshot persistence with `src/utils/session-storage.ts`
- Integrate resume on mount + save-on-change + clear-on-reset into `src/app/page.tsx`
- Add unit tests for session storage utility and adjust page tests to clear `session_v1`

Validation:
- All tests pass locally: 133/133 suites green
- Type checks pass

Notes:
- Sharing Replace flow does not modify `session_v1`, keeping resume intact
- Minimal risk; confined to localStorage reads/writes and page wiring

Follow-ups:
- Optional E2E to verify reload-resume behavior
- Consider a guard if we ever need to disable auto-resume in specific contexts