### PR TITLE
Fix #352: warn and disable network-dependent share actions when offline

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -11,7 +11,7 @@ try {
 const CACHE_NAME_PREFIX = 'github-copilot-agent-assisted-next-app';
 // Use consistent version - will be replaced at build time or deployment
 // This ensures consistent cache versioning across all instances
-const BUILD_VERSION = '0.1.0-1756118601872'; // Format: package.version-increment
+const BUILD_VERSION = '0.1.0-1756127391081'; // Format: package.version-increment
 const CACHE_NAME = `${CACHE_NAME_PREFIX}-v${BUILD_VERSION}`;
 const APP_SHELL_CACHE_NAME = `app-shell-v${BUILD_VERSION}`;
 

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -7,6 +7,7 @@ import { useApiKey } from '@/contexts/ApiKeyContext';
 import { useOpenAIClient } from '@/utils/ai/byokClient';
 import type { ChatCompletion } from '@/types/ai';
 import { MAX_AI_ACTIVITIES } from '@/types/ai';
+import useNetworkStatus from '@/hooks/useNetworkStatus';
 
 export default function AIPlannerPage() {
   const router = useRouter();
@@ -20,6 +21,7 @@ export default function AIPlannerPage() {
   const { apiKey, setApiKey, clearApiKey } = useApiKey();
   const { callOpenAI } = useOpenAIClient();
   const PROMPT_STORAGE_KEY = 'ai_planner_last_prompt';
+  const { online } = useNetworkStatus();
 
   useEffect(() => {
     // Hydration guard for client-only rendering
@@ -201,6 +203,12 @@ export default function AIPlannerPage() {
           </h5>
         </Card.Header>
         <Card.Body>
+          {/* Show prominent offline warning when not connected */}
+          {!online && (
+            <Alert variant="warning" role="alert" data-testid="ai-offline-warning" className="mb-3">
+              AI planning requires a network connection — you are currently offline. Reconnect to use this feature.
+            </Alert>
+          )}
           <Form onSubmit={handlePlan} aria-label="AI planning form">
             <Form.Group className="mb-3">
               <Form.Label htmlFor="aiPrompt">Describe your session</Form.Label>
@@ -221,7 +229,14 @@ export default function AIPlannerPage() {
               <Alert variant="danger" role="alert">{error}</Alert>
             )}
             <div className="d-flex gap-2">
-              <Button type="submit" variant="primary" disabled={loading} aria-label="Generate AI plan">
+              <Button
+                type="submit"
+                variant="primary"
+                disabled={loading || !online}
+                aria-disabled={loading || !online}
+                title={!online ? 'You are offline. Reconnect to plan with AI.' : 'Generate AI plan'}
+                aria-label="Generate AI plan"
+              >
                 {loading ? (<><Spinner size="sm" className="me-2" animation="border" />Planning…</>) : 'Plan with AI'}
               </Button>
               <Button type="button" variant="outline-danger" onClick={() => { clearApiKey(); addToast({ message: 'API key cleared', variant: 'success' }); }}>

--- a/src/components/ActivityManager.tsx
+++ b/src/components/ActivityManager.tsx
@@ -10,6 +10,7 @@ import { useResponsiveToast } from '@/hooks/useResponsiveToast';
 import { getActivities, addActivity as persistActivity, deleteActivity as persistDeleteActivity } from '../utils/activity-storage';
 import { Activity as CanonicalActivity } from '../types/activity';
 import { fetchWithVercelBypass } from '@/utils/fetchWithVercelBypass';
+import useNetworkStatus from '@/hooks/useNetworkStatus';
 
 // Use canonical Activity type
 type Activity = CanonicalActivity & { colors?: ColorSet };
@@ -193,6 +194,10 @@ export default function ActivityManager({
 
   const handleCreateShare = useCallback(async () => {
     try {
+      if (!online) {
+        addResponsiveToast({ message: 'Cannot create share: no network connection. Please reconnect and try again.', variant: 'warning', autoDismiss: true });
+        return;
+      }
       setShareLoading(true);
       const payload = {
         sessionData: {
@@ -229,6 +234,8 @@ export default function ActivityManager({
       setShareLoading(false);
     }
   }, [activities, timelineEntries, addResponsiveToast]);
+
+  const { online } = useNetworkStatus();
 
   return (
     <Card className="h-100 d-flex flex-column" data-testid="activity-manager">
@@ -267,6 +274,7 @@ export default function ActivityManager({
               variant="outline-success"
               size="sm"
               onClick={() => setShowShareModal(true)}
+              disabled={!online}
               className="d-flex align-items-center"
               title="Share session"
               data-testid="open-share-modal"
@@ -372,6 +380,9 @@ export default function ActivityManager({
               <Spinner animation="border" size="sm" className="me-2" /> Creating share...
             </div>
           )}
+            {!online && (
+              <div className="text-muted small mt-2" data-testid="activitymanager-share-offline-warning">Sharing requires a network connection — you are currently offline.</div>
+            )}
           {showShareControls && shareUrl && (
             <div className="mt-3">
               <ShareControls shareUrl={shareUrl} />
@@ -385,6 +396,7 @@ export default function ActivityManager({
               <Button
                 variant="success"
                 onClick={handleCreateShare}
+                disabled={!online}
               >
                 Create share
               </Button>

--- a/src/components/ActivityManager.tsx
+++ b/src/components/ActivityManager.tsx
@@ -192,6 +192,8 @@ export default function ActivityManager({
   const visibleActivities = activities.filter(a => !hiddenSet.has(a.id));
   const hiddenActivities = activities.filter(a => hiddenSet.has(a.id));
 
+  const { online } = useNetworkStatus();
+
   const handleCreateShare = useCallback(async () => {
     try {
       if (!online) {
@@ -233,9 +235,9 @@ export default function ActivityManager({
     } finally {
       setShareLoading(false);
     }
-  }, [activities, timelineEntries, addResponsiveToast]);
+  }, [activities, timelineEntries, addResponsiveToast, online]);
 
-  const { online } = useNetworkStatus();
+  // Note: `online` is intentionally included in the handleCreateShare dependency array
 
   return (
     <Card className="h-100 d-flex flex-column" data-testid="activity-manager">

--- a/src/components/ShareControls.tsx
+++ b/src/components/ShareControls.tsx
@@ -25,6 +25,8 @@ export default function ShareControls({ shareUrl, showOpen = false, showReplace 
   const confirmRef = useRef<ConfirmationDialogRef>(null);
   const [isReplacing, setIsReplacing] = useState(false);
 
+  // Network status hook - place with other hooks at top of component for clarity
+  const { online } = useNetworkStatus();
 
   const copy = async () => {
     try {
@@ -149,7 +151,6 @@ export default function ShareControls({ shareUrl, showOpen = false, showReplace 
     confirmRef.current?.showDialog();
   };
 
-  const { online } = useNetworkStatus();
 
   return (
     <div

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -714,6 +714,17 @@ export default function Summary({
         <Modal.Body>
           <p id="share-modal-desc">Share a read-only copy of the current session. This will create a public URL that anyone can open.</p>
           <p className="text-muted small">The shared session will contain summary and timeline data only.</p>
+          {/* Offline warning shown prominently inside dialog body, not between footer buttons */}
+          {!showShareControls && !online && (
+            <Alert
+              variant="warning"
+              role="alert"
+              className="mb-3"
+              data-testid="share-offline-warning"
+            >
+              Sharing requires a network connection — you are currently offline.
+            </Alert>
+          )}
           {shareLoading && (
             <div className="d-flex align-items-center">
               <Spinner animation="border" size="sm" className="me-2" /> Creating share...
@@ -726,7 +737,7 @@ export default function Summary({
           )}
         </Modal.Body>
         <Modal.Footer>
-              {!showShareControls && (
+          {!showShareControls && (
             <>
               <Button
                 variant="secondary"
@@ -734,18 +745,15 @@ export default function Summary({
               >
                 Cancel
               </Button>
-                  <div className="d-flex flex-column align-items-end">
-                    {!online && (
-                      <div className="text-muted small mb-2" data-testid="share-offline-warning">Sharing requires a network connection — you are currently offline.</div>
-                    )}
-                    <Button
-                      variant="success"
-                      onClick={handleCreateShare}
-                      disabled={!online}
-                    >
-                      Create share
-                    </Button>
-                  </div>
+              <Button
+                variant="success"
+                onClick={handleCreateShare}
+                disabled={!online}
+                aria-disabled={!online}
+                title={!online ? 'You are offline. Reconnect to create a share.' : 'Create share'}
+              >
+                Create share
+              </Button>
             </>
           )}
           {showShareControls && (

--- a/src/components/__tests__/ShareControls.offline.test.tsx
+++ b/src/components/__tests__/ShareControls.offline.test.tsx
@@ -14,13 +14,12 @@ jest.mock('@/hooks/useResponsiveToast', () => ({
 }));
 
 describe('ShareControls offline behavior', () => {
-  const originalNavigator = { ...(window as any).navigator };
+  const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(window, 'navigator');
 
   afterEach(() => {
-    Object.defineProperty(window, 'navigator', {
-      configurable: true,
-      value: originalNavigator,
-    });
+    if (originalNavigatorDescriptor) {
+      Object.defineProperty(window, 'navigator', originalNavigatorDescriptor);
+    }
   });
 
   it('disables download/open/replace buttons when offline', () => {
@@ -31,17 +30,15 @@ describe('ShareControls offline behavior', () => {
 
     render(<ShareControls shareUrl="/shared/123" showOpen={true} showReplace={true} />);
 
-    // Copy button should be enabled (no network required)
-    const copyButton = screen.getByRole('button', { name: /copy share link/i });
-    expect(copyButton).toBeEnabled();
+  // Copy button should be enabled (no network required)
+  const copyButton = screen.getByRole('button', { name: /copy share link/i });
+  expect(copyButton).toBeEnabled();
 
-    const downloadButton = screen.getByRole('button', { name: /download json/i });
-    expect(downloadButton).toBeDisabled();
+  const downloadButton = screen.getByRole('button', { name: /download json/i });
+  expect(downloadButton).toBeDisabled();
 
-    const openButton = screen.getByRole('button', { name: /open shared session in new window/i });
-    // open action should be disabled via toast guard earlier, but DOM may still enable the button — we guard open at click-time
-    // We assert download and replace (replace should be disabled)
-    const replaceButton = screen.getByRole('button', { name: /replace my activities/i });
-    expect(replaceButton).toBeDisabled();
+  // Replace action should be disabled while offline
+  const replaceButton = screen.getByRole('button', { name: /replace my activities/i });
+  expect(replaceButton).toBeDisabled();
   });
 });

--- a/src/components/__tests__/ShareControls.offline.test.tsx
+++ b/src/components/__tests__/ShareControls.offline.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import ShareControls from '../ShareControls';
+
+// Mock next/navigation's useRouter to avoid runtime mount errors in Jest
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+// Mock useResponsiveToast used by ShareControls
+jest.mock('@/hooks/useResponsiveToast', () => ({
+  useResponsiveToast: () => ({ addResponsiveToast: jest.fn() }),
+}));
+
+describe('ShareControls offline behavior', () => {
+  const originalNavigator = { ...(window as any).navigator };
+
+  afterEach(() => {
+    Object.defineProperty(window, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    });
+  });
+
+  it('disables download/open/replace buttons when offline', () => {
+    Object.defineProperty(window, 'navigator', {
+      configurable: true,
+      value: { onLine: false },
+    });
+
+    render(<ShareControls shareUrl="/shared/123" showOpen={true} showReplace={true} />);
+
+    // Copy button should be enabled (no network required)
+    const copyButton = screen.getByRole('button', { name: /copy share link/i });
+    expect(copyButton).toBeEnabled();
+
+    const downloadButton = screen.getByRole('button', { name: /download json/i });
+    expect(downloadButton).toBeDisabled();
+
+    const openButton = screen.getByRole('button', { name: /open shared session in new window/i });
+    // open action should be disabled via toast guard earlier, but DOM may still enable the button — we guard open at click-time
+    // We assert download and replace (replace should be disabled)
+    const replaceButton = screen.getByRole('button', { name: /replace my activities/i });
+    expect(replaceButton).toBeDisabled();
+  });
+});

--- a/src/hooks/__tests__/useNetworkStatus.test.tsx
+++ b/src/hooks/__tests__/useNetworkStatus.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import useNetworkStatus from '../useNetworkStatus';
+
+describe('useNetworkStatus (integration)', () => {
+  const originalNavigator = { ...(window as any).navigator };
+
+  afterEach(() => {
+    // Restore original navigator object after each test
+    Object.defineProperty(window, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    });
+  });
+
+  function TestComponent() {
+    const { online } = useNetworkStatus();
+    return <div data-testid="status">{online ? 'online' : 'offline'}</div>;
+  }
+
+  it('shows offline/online as navigator changes', async () => {
+    // Ensure the hook reads the mocked navigator from window
+    Object.defineProperty(window, 'navigator', {
+      configurable: true,
+      value: { onLine: false },
+    });
+    render(<TestComponent />);
+    expect(screen.getByTestId('status').textContent).toBe('offline');
+
+    // simulate becoming online
+    // Simulate navigator becoming online and dispatch the event
+    Object.defineProperty(window, 'navigator', {
+      configurable: true,
+      value: { onLine: true },
+    });
+    act(() => {
+      window.dispatchEvent(new Event('online'));
+    });
+    await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('online'));
+
+    // simulate going offline
+    Object.defineProperty(window, 'navigator', {
+      configurable: true,
+      value: { onLine: false },
+    });
+    act(() => {
+      window.dispatchEvent(new Event('offline'));
+    });
+    await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('offline'));
+  });
+});

--- a/src/hooks/__tests__/useNetworkStatus.test.tsx
+++ b/src/hooks/__tests__/useNetworkStatus.test.tsx
@@ -4,14 +4,14 @@ import { act } from 'react';
 import useNetworkStatus from '../useNetworkStatus';
 
 describe('useNetworkStatus (integration)', () => {
-  const originalNavigator = { ...(window as any).navigator };
+  // Capture a shallow copy of the original navigator for restoration.
+  // Use unknown to avoid `any` lint rule and then cast to PropertyDescriptor-friendly type.
+  const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(window, 'navigator');
 
   afterEach(() => {
-    // Restore original navigator object after each test
-    Object.defineProperty(window, 'navigator', {
-      configurable: true,
-      value: originalNavigator,
-    });
+    if (originalNavigatorDescriptor) {
+      Object.defineProperty(window, 'navigator', originalNavigatorDescriptor);
+    }
   });
 
   function TestComponent() {

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -21,7 +21,9 @@ export default function useNetworkStatus() {
     // In some test environments the navigator.onLine may be out-of-date
     // so check once on mount to sync state.
     try {
-      setOnline(Boolean((navigator && (navigator as any).onLine) ?? true));
+      // Avoid using `any` casts for navigator; narrow safely
+      const nav = typeof navigator !== 'undefined' ? navigator : undefined;
+      setOnline(Boolean(nav?.onLine ?? true));
     } catch {
       // ignore
     }

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+// Simple hook that exposes whether the browser is online and updates
+// in response to the native `online` / `offline` events. Keeps implementation
+// minimal and safe for SSR by checking typeof window.
+export default function useNetworkStatus() {
+  const [online, setOnline] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true; // assume online on server
+    return typeof navigator !== 'undefined' ? navigator.onLine : true;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleOnline = () => setOnline(true);
+    const handleOffline = () => setOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    // In some test environments the navigator.onLine may be out-of-date
+    // so check once on mount to sync state.
+    try {
+      setOnline(Boolean((navigator && (navigator as any).onLine) ?? true));
+    } catch {
+      // ignore
+    }
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return { online };
+}


### PR DESCRIPTION
## Problem
Some share-related actions (creating shares, downloading shared JSON, replacing from shared JSON, opening shared link) require a network connection; attempting them while offline is confusing and can fail silently.

## Solution
- Added `src/hooks/useNetworkStatus.ts` – small SSR-safe hook exposing `{ online }` and listening for `online`/`offline` events.
- Updated `src/components/ShareControls.tsx` – disable download/replace buttons when offline and show warning toast on attempts while offline. Copy remains available offline.
- Updated `src/components/Summary.tsx` and `src/components/ActivityManager.tsx` – share create actions are guarded when offline; modal create buttons disabled and inline warnings shown.
- Added tests:
  - `src/hooks/__tests__/useNetworkStatus.test.tsx`
  - `src/components/__tests__/ShareControls.offline.test.tsx`

## Tests
- Targeted tests for offline behavior added and passing locally. Please run full test suite in CI.

Fixes #352
